### PR TITLE
Bugfix in OutputImage class

### DIFF
--- a/yolo_model_development_kit/inference_pipeline/source/output_image.py
+++ b/yolo_model_development_kit/inference_pipeline/source/output_image.py
@@ -103,7 +103,7 @@ class OutputImage:
         """
         img_height, img_width, _ = self.image.shape
 
-        if categories:
+        if categories is not None:
             colours = [colour_map[category] for category in categories]
         else:
             colours = [(255, 0, 0)] * len(boxes)


### PR DESCRIPTION
There was an issue when drawing multiple bounding boxes caused by an incorrect `None` check.