### PR TITLE
Bugfix/logging loop

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -93,8 +93,8 @@ wandb:
   mode: "offline"
 
 logging:
-  loglevel_own: DEBUG  # override loglevel for packages defined in `own_packages`
-  own_packages: ["__main__", "yolo_model_development_kit", "performance_evaluation", "training_pipeline"]
+  loglevel_own: INFO  # override loglevel for packages defined in `own_packages`
+  own_packages: ["__main__", "yolo_model_development_kit", "performance_evaluation", "training_pipeline", "inference_pipeline"]
   basic_config:
     # log config as arguments to `logging.basicConfig`
     level: WARNING

--- a/yolo_model_development_kit/inference_pipeline/source/YOLO_inference.py
+++ b/yolo_model_development_kit/inference_pipeline/source/YOLO_inference.py
@@ -16,6 +16,9 @@ from yolo_model_development_kit.inference_pipeline.source.model_result import (
 )
 
 logger = logging.getLogger("inference_pipeline")
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(
+    logging.WARNING
+)
 
 
 class YOLOInference:

--- a/yolo_model_development_kit/inference_pipeline/source/YOLO_inference.py
+++ b/yolo_model_development_kit/inference_pipeline/source/YOLO_inference.py
@@ -17,6 +17,7 @@ from yolo_model_development_kit.inference_pipeline.source.model_result import (
 )
 
 logger = logging.getLogger("inference_pipeline")
+# TODO: Workaround to suppress excessive logging from azure, should be fixed better in the future
 logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(
     logging.WARNING
 )


### PR DESCRIPTION
Workaround to suppress excessive logging from azure. It was caused by a conflict with SAHI library overriding the default logger level.