### PR TITLE
Fix/training pipeline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -53,7 +53,9 @@ training_pipeline:
     project_datastore_path: "dataset_oor_v2_2"
     project_rel_path: "model"
     project_name: "yolo11m_base"  # can be an empty string or omitted entirely, will be ignored in sweep mode
+    experiment_name: ""
   sweep_mode: False  # Set to true to run a hyperparameter sweep based on inputs/sweep_config
+  sweep_trials: 1 # will be ignored in train mode
 
 wandb:
   api_key: ""

--- a/config.yml
+++ b/config.yml
@@ -52,11 +52,14 @@ training_pipeline:
   outputs:
     project_datastore_path: "dataset_oor_v2_2"
     project_rel_path: "model"
+    project_name: "yolo11m_base"  # can be an empty string or omitted entirely, will be ignored in sweep mode
   sweep_mode: False  # Set to true to run a hyperparameter sweep based on inputs/sweep_config
 
 wandb:
   api_key: ""
   mode: "offline"
+  entity: "a-lombardo-ggd-amsterdam"  # W&B entity to log the run to (default: null)
+  project_name: "baas_v11"  # W&B project name
 
 logging:
   loglevel_own: DEBUG  # override loglevel for packages defined in `own_packages`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "~3.12"
+python = ">=3.10, <=3.12"
 pre-commit = "^3.8.0"
 aml_interface = { git = "https://github.com/Computer-Vision-Team-Amsterdam/AML-Interface.git", tag = "v1.1.2" }
 azure-ai-ml = {version = "^1.2.0", source = "PyPI"}

--- a/yolo_model_development_kit/settings/settings_schema.py
+++ b/yolo_model_development_kit/settings/settings_schema.py
@@ -73,6 +73,8 @@ class TrainingPipelineSpec(SettingsSpecModel):
 class WandbSpec(SettingsSpecModel):
     api_key: str
     mode: str = "disabled"
+    entity: Optional[str] = None
+    project_name: str
 
 
 class YoloModelDevelopmentKitSettingsSpec(SettingsSpecModel):

--- a/yolo_model_development_kit/settings/settings_schema.py
+++ b/yolo_model_development_kit/settings/settings_schema.py
@@ -68,6 +68,7 @@ class TrainingPipelineSpec(SettingsSpecModel):
     inputs: Dict[str, str] = None
     outputs: Dict[str, str] = None
     sweep_mode: bool = False
+    sweep_trials: int = 1
 
 
 class WandbSpec(SettingsSpecModel):

--- a/yolo_model_development_kit/training_pipeline/components/sweep_model.py
+++ b/yolo_model_development_kit/training_pipeline/components/sweep_model.py
@@ -7,9 +7,11 @@ import wandb
 import yaml
 from azure.ai.ml.constants import AssetTypes
 from mldesigner import Input, Output, command_component
-from ultralytics import YOLO
 from ultralytics import settings as ultralytics_settings
-from wandb.integration.ultralytics import add_wandb_callback
+
+ultralytics_settings.update({"wandb": True})
+from ultralytics import YOLO  # noqa: E402
+from wandb.integration.ultralytics import add_wandb_callback  # noqa: E402
 
 sys.path.append("../../..")
 
@@ -122,7 +124,6 @@ def sweep_model(
 
             add_wandb_callback(
                 model,
-                enable_model_checkpointing=False,
                 enable_validation_logging=False,
                 enable_prediction_logging=False,
                 enable_train_validation_logging=False,

--- a/yolo_model_development_kit/training_pipeline/components/sweep_model.py
+++ b/yolo_model_development_kit/training_pipeline/components/sweep_model.py
@@ -85,13 +85,19 @@ def sweep_model(
     model_parameters = settings["training_pipeline"]["model_parameters"]
     sweep_trials = settings["training_pipeline"]["sweep_trials"]
 
+    # The batch_size can be a float between 0 and 1, or a positive int.
+    # This is ambiguous in the config.yml parsing, so we need to fix it here.
+    batch_size = model_parameters.get("batch", -1)
+    if (batch_size >= 1) and (isinstance(batch_size, float)):
+        batch_size = int(batch_size)
+
     train_params = {
         "data": yaml_path,
         "epochs": model_parameters.get("epochs", 100),
         "imgsz": model_parameters.get("img_size", 1024),
         "project": project_path,
         "save_dir": project_path,
-        "batch": model_parameters.get("batch", -1),
+        "batch": batch_size,
     }
 
     # Define the search space

--- a/yolo_model_development_kit/training_pipeline/components/train_model.py
+++ b/yolo_model_development_kit/training_pipeline/components/train_model.py
@@ -145,12 +145,12 @@ def train_model(
 
     train_params.update(train_params_from_json)  # Update with dynamically loaded params
 
-    # wandb.init(
-    #     job_type="training",
-    #     entity=settings["wandb"]["entity"],
-    #     project=settings["wandb"]["project_name"],
-    #     name=experiment_name,
-    # )
+    wandb.init(
+        job_type="training",
+        entity=settings["wandb"]["entity"],
+        project=settings["wandb"]["project_name"],
+        name=experiment_name,
+    )
 
     model = YOLO(model=pretrained_model_path, task="detect")
 


### PR DESCRIPTION
This PR adapts the code to correctly log training/sweeps runs in weights & biases. It includes:
- add custom project name and W&B entity as parameters
- update the pipeline to work with a new update of W&B in Ultralytics
- add missing W&B parameters in _config.yml_
- fix `batch_size `bug where a `float `in the config file would be considered ambiguous by W&B.

The code has been tested in both sweep and training mode.