### PR TITLE
Bugfix/bcv-1666: fix ZeroDivisionError in per_image_stats.py

### DIFF
--- a/yolo_model_development_kit/performance_evaluation_pipeline/components/evaluate_model.py
+++ b/yolo_model_development_kit/performance_evaluation_pipeline/components/evaluate_model.py
@@ -28,7 +28,7 @@ aml_experiment_settings = settings["aml_experiment_details"]
     display_name="Evaluate model predictions.",
     environment=f"azureml:{aml_experiment_settings['env_name']}:{aml_experiment_settings['env_version']}",
     code="../../../",
-    is_deterministic=True,
+    is_deterministic=False,
 )
 def evaluate_model(
     ground_truth_base_dir: Input(type=AssetTypes.URI_FOLDER),  # type: ignore # noqa: F821

--- a/yolo_model_development_kit/performance_evaluation_pipeline/components/perform_bias_analysis.py
+++ b/yolo_model_development_kit/performance_evaluation_pipeline/components/perform_bias_analysis.py
@@ -29,7 +29,7 @@ aml_experiment_settings = settings["aml_experiment_details"]
     display_name="Perform Bias Analysis on a model.",
     environment=f"azureml:{aml_experiment_settings['env_name']}:{aml_experiment_settings['env_version']}",
     code="../../../",
-    is_deterministic=True,
+    is_deterministic=False,
 )
 def perform_bias_analysis(
     predictions_base_dir: Input(type=AssetTypes.URI_FOLDER),  # type: ignore # noqa: F821

--- a/yolo_model_development_kit/performance_evaluation_pipeline/metrics/per_image_stats.py
+++ b/yolo_model_development_kit/performance_evaluation_pipeline/metrics/per_image_stats.py
@@ -179,9 +179,9 @@ class PerImageEvaluator:
 
         precision = round(tp / PP, self.decimals) if PP > 0 else np.nan
         recall = round(tp / P, self.decimals) if P > 0 else np.nan
-        fpr = round(fp / N, self.decimals)
+        fpr = round(fp / N, self.decimals) if N > 0 else np.nan
         fnr = round(fn / P, self.decimals) if P > 0 else np.nan
-        tnr = round(tn / N, self.decimals)
+        tnr = round(tn / N, self.decimals) if N > 0 else np.nan
 
         return {
             "precision": precision if size_all else np.nan,


### PR DESCRIPTION
Currently the code does not consider the possibility that every image has at least one ground truth annotation for the target class, so `self.gt_all - ground_truth` results in an empty set, throwing a `ZeroDivisionError`.

With this fix we check if that's the case, and if it is we set FPR and TNR to `np.nan`.